### PR TITLE
Fix discount calculation for subscription tiers

### DIFF
--- a/src/Order.java
+++ b/src/Order.java
@@ -78,11 +78,11 @@ public class Order {
         }
 
         if (subscription == "gold") {
-            totalPrice *= 0.15; // 15% discount for prime members
+            totalPrice *= 0.85; // 15% discount for gold members (1 - 0.15 = 0.85)
         } else if (subscription == "platinum") {
-            totalPrice *= 0.10; // 10% discount for platinum members
+            totalPrice *= 0.90; // 10% discount for platinum members (1 - 0.10 = 0.90)
         } else if (subscription == "silver") {
-            totalPrice *= 0.05; // 5% discount for silver members
+            totalPrice *= 0.95; // 5% discount for silver members (1 - 0.05 = 0.95)
         } 
 
         return totalPrice;


### PR DESCRIPTION
Corrects the discount logic for gold, platinum, and silver subscriptions by applying the proper percentage reduction to totalPrice. Previously, the code multiplied by the discount rate instead of subtracting it from 1.

- Fixes #3 